### PR TITLE
netlink: Add rx_nohandler link stat counter

### DIFF
--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -60,6 +60,11 @@ static struct bmon_module netlink_ops;
 # define RTNL_LINK_IP6_CEPKTS		-1
 #endif
 
+/* Not available prior to libnl 3.2.29 */
+#if LIBNL_CURRENT < 224
+# define RTNL_LINK_RX_NOHANDLER		-1
+#endif
+
 static struct attr_map link_attrs[] = {
 {
 	.name		= "bytes",
@@ -100,6 +105,14 @@ static struct attr_map link_attrs[] = {
 	.description	= "Compressed",
 	.rxid		= RTNL_LINK_RX_COMPRESSED,
 	.txid		= RTNL_LINK_TX_COMPRESSED,
+},
+{
+	.name		= "nohandler",
+	.type		= ATTR_TYPE_COUNTER,
+	.unit		= UNIT_NUMBER,
+	.description	= "No Handler",
+	.rxid		= RTNL_LINK_RX_NOHANDLER,
+	.txid		= -1,
 },
 {
 	.name		= "fifoerr",


### PR DESCRIPTION
Hook up the device rx nohandler stat counter available in the upcoming
libnl 3.2.29, added in libnl commit 5040fc8a4994 ("lib/route: add
rx_nohandler link stats field").

Also add a compatibility define, so older libnl version will still work
fine.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>