### PR TITLE
Increase buffer size to avoid possible truncation:

### DIFF
--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -550,7 +550,7 @@ static void find_qdiscs(int, uint32_t, struct rdata *);
 static struct element *handle_tc_obj(struct rtnl_tc *tc, const char *prefix,
 				     const struct rdata *rdata)
 {
-	char buf[IFNAME_MAX], name[IFNAME_MAX];
+	char buf[IFNAME_MAX], name[IFNAME_MAX + 6];
 	uint32_t id = rtnl_tc_get_handle(tc);
 	struct element *e;
 


### PR DESCRIPTION
  CC       bmon-in_netlink.o
in_netlink.c: In function ‘handle_tc_obj’:
in_netlink.c:558:37: warning: ‘ (’ directive output may be truncated writing 2 bytes into a region of size between 0 and 31 [-Wformat-truncation=]
  558 |  snprintf(name, sizeof(name), "%s %s (%s)",
      |                                     ^~
in_netlink.c:558:2: note: ‘snprintf’ output 5 or more bytes (assuming 36) into a destination of size 32
  558 |  snprintf(name, sizeof(name), "%s %s (%s)",
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  559 |    prefix, buf, rtnl_tc_get_kind(tc));
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CCLD     bmon