### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -27,7 +27,7 @@
 #include <bmon/conf.h>
 #include <bmon/utils.h>
 
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -117,7 +117,7 @@ int timestamp_is_negative(timestamp_t *ts)
 
 void update_timestamp(timestamp_t *dst)
 {
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 	clock_serv_t cclock;
 	mach_timespec_t tp;
 


### PR DESCRIPTION
As said in a3d894000b7243e4bfd54f99de3bee8154827897, this check is only intended for OSX.
```
Instead of using gettimeofday(), switch to clock_gettime() with
CLOCK_MONOTONIC on systems that support it.  OS X does not provide
clock_gettime(), so this commit also adds a Mach-specific implementation.
```

Hurd also uses Mach, but does not have the same shortcomings as OSX in this area.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```