### PR TITLE
display filters for TC ingress and egress

### DIFF
--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -703,14 +703,27 @@ static void handle_qdisc(struct nl_object *obj, void *arg)
 
 	ndata.parent = e;
 
-	find_cls(rtnl_tc_get_ifindex(tc), rtnl_tc_get_handle(tc), &ndata);
-
-	if (rtnl_tc_get_parent(tc) == TC_H_ROOT) {
+	switch(rtnl_tc_get_parent(tc)) {
+	case TC_H_INGRESS:
+		if (!strcmp(rtnl_tc_get_kind(tc), "clsact")) {
+			 find_cls(rtnl_tc_get_ifindex(tc),
+				  TC_H_MAKE(TC_H_CLSACT, TC_H_MIN_INGRESS),
+				  &ndata);
+			 find_cls(rtnl_tc_get_ifindex(tc),
+				  TC_H_MAKE(TC_H_CLSACT, TC_H_MIN_EGRESS),
+				  &ndata);
+		} else {
+			find_cls(rtnl_tc_get_ifindex(tc), TC_H_INGRESS, &ndata);
+		}
+		break;
+	case TC_H_ROOT:
 		find_cls(rtnl_tc_get_ifindex(tc), TC_H_ROOT, &ndata);
 		find_classes(TC_H_ROOT, &ndata);
+		/* fall-through */
+	default:
+		find_cls(rtnl_tc_get_ifindex(tc), rtnl_tc_get_handle(tc), &ndata);
+		find_classes(rtnl_tc_get_handle(tc), &ndata);
 	}
-
-	find_classes(rtnl_tc_get_handle(tc), &ndata);
 }
 
 static void handle_tc(struct element *e, struct rtnl_link *link)

--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -704,8 +704,10 @@ static void handle_qdisc(struct nl_object *obj, void *arg)
 	ndata.parent = e;
 
 	switch(rtnl_tc_get_parent(tc)) {
-	case TC_H_INGRESS:
-		if (!strcmp(rtnl_tc_get_kind(tc), "clsact")) {
+	case TC_H_INGRESS: {
+		const char *kind = rtnl_tc_get_kind(tc);
+
+		if (kind && !strcmp(kind, "clsact")) {
 			 find_cls(rtnl_tc_get_ifindex(tc),
 				  TC_H_MAKE(TC_H_CLSACT, TC_H_MIN_INGRESS),
 				  &ndata);
@@ -716,6 +718,7 @@ static void handle_qdisc(struct nl_object *obj, void *arg)
 			find_cls(rtnl_tc_get_ifindex(tc), TC_H_INGRESS, &ndata);
 		}
 		break;
+	}
 	case TC_H_ROOT:
 		find_cls(rtnl_tc_get_ifindex(tc), TC_H_ROOT, &ndata);
 		find_classes(TC_H_ROOT, &ndata);


### PR DESCRIPTION
the TC clsact qdisc has the same handle as ingress: however, ingress and egress filters parent to ffff:fff2 and ffff:fff3 respectively. Explicitly request the above 2 handles, so that ingress and egress filters attached to clsact are displayed.

Signed-off-by: Davide Caratti <dcaratti@redhat.com>