### PR TITLE
curses: render graphs with Braille cells

### DIFF
--- a/include/bmon/graph.h
+++ b/include/bmon/graph.h
@@ -31,6 +31,9 @@
 
 struct history;
 
+#define GRAPH_CFG_BRAILLE		0x01
+#define GRAPH_BRAILLE_CELL_BYTES	3
+
 struct graph_cfg {
 	int			gc_height,
 				gc_width,

--- a/src/graph.c
+++ b/src/graph.c
@@ -32,10 +32,18 @@
 #include <bmon/unit.h>
 #include <bmon/utils.h>
 
+#define GRAPH_BRAILLE_ROWS	4
+
+static inline size_t graph_cell_size(struct graph_cfg *cfg)
+{
+	return (cfg->gc_flags & GRAPH_CFG_BRAILLE) ?
+		GRAPH_BRAILLE_CELL_BYTES : 1;
+}
+
 size_t graph_row_size(struct graph_cfg *cfg)
 {
 	/* +1 for trailing \0 */
-	return cfg->gc_width + 1;
+	return (cfg->gc_width * graph_cell_size(cfg)) + 1;
 }
 
 static inline size_t table_size(struct graph_cfg *cfg)
@@ -48,14 +56,171 @@ static inline char *at_row(struct graph_cfg *cfg, char *col, int nrow)
 	return col + (nrow * graph_row_size(cfg));
 }
 
-static inline char *at_col(char *row, int ncol)
+static inline char *at_col(struct graph_cfg *cfg, char *row, int ncol)
 {
-	return row + ncol;
+	return row + (ncol * graph_cell_size(cfg));
 }
 
 static inline char *tbl_pos(struct graph_cfg *cfg, char *tbl, int nrow, int ncol)
 {
-	return at_col(at_row(cfg, tbl, nrow), ncol);
+	return at_col(cfg, at_row(cfg, tbl, nrow), ncol);
+}
+
+static int history_index_at(struct history *h, int ncol)
+{
+	int n = h->h_index - 1 - ncol;
+
+	while (n < 0)
+		n += h->h_definition->hd_size;
+
+	return n;
+}
+
+static uint64_t graph_data_at(struct history *h, struct history_store *data,
+			      int ncol)
+{
+	return history_data(h, data, history_index_at(h, ncol));
+}
+
+static void put_braille(char *pos, unsigned char dots)
+{
+	unsigned int cp = 0x2800 + dots;
+
+	pos[0] = (char) (0xe0 | (cp >> 12));
+	pos[1] = (char) (0x80 | ((cp >> 6) & 0x3f));
+	pos[2] = (char) (0x80 | (cp & 0x3f));
+}
+
+static unsigned char braille_dot_bit(int x, int y)
+{
+	static const unsigned char bits[2][GRAPH_BRAILLE_ROWS] = {
+		{ 0x40, 0x04, 0x02, 0x01 },
+		{ 0x80, 0x20, 0x10, 0x08 },
+	};
+
+	return bits[x][y];
+}
+
+static void braille_plot_value(struct graph_cfg *cfg, unsigned char *dots,
+			       int ncol, int x, double v, double step)
+{
+	int i, ndots;
+	int maxdots = cfg->gc_height * GRAPH_BRAILLE_ROWS;
+
+	if (v <= 0.0f || step <= 0.0f)
+		return;
+
+	ndots = (int) ((v / step) + 0.5f);
+	if (ndots < 1)
+		ndots = 1;
+	if (ndots > maxdots)
+		ndots = maxdots;
+
+	for (i = 0; i < ndots; i++) {
+		int nrow = i / GRAPH_BRAILLE_ROWS;
+		int y = i % GRAPH_BRAILLE_ROWS;
+
+		dots[(nrow * cfg->gc_width) + ncol] |=
+			braille_dot_bit(x, y);
+	}
+}
+
+static void fill_braille_unknown(struct graph_cfg *cfg, unsigned char *dots,
+				 int ncol)
+{
+	int i;
+
+	for (i = 0; i < cfg->gc_height; i++)
+		dots[(i * cfg->gc_width) + ncol] = 0xff;
+}
+
+static void render_braille_table(struct graph_cfg *cfg, char *tbl,
+				 unsigned char *dots)
+{
+	int i, n;
+
+	for (i = 0; i < cfg->gc_height; i++) {
+		for (n = 0; n < cfg->gc_width; n++)
+			put_braille(tbl_pos(cfg, tbl, i, n),
+				    dots[(i * cfg->gc_width) + n]);
+
+		*tbl_pos(cfg, tbl, i, cfg->gc_width) = '\0';
+	}
+}
+
+static void fill_braille_table(struct graph *g, struct graph_table *tbl,
+			       struct history *h, struct history_store *data)
+{
+	struct graph_cfg *cfg = &g->g_cfg;
+	uint64_t max = 0;
+	unsigned char *dots;
+	double step, dot_step, divisor;
+	int i, n;
+
+	if (!tbl->gt_table) {
+		tbl->gt_table = xcalloc(table_size(cfg), sizeof(char));
+		tbl->gt_scale = xcalloc(cfg->gc_height, sizeof(double));
+	}
+
+	dots = xcalloc(cfg->gc_height * cfg->gc_width, sizeof(*dots));
+	render_braille_table(cfg, tbl->gt_table, dots);
+
+	/* leave table blank if there is no data */
+	if (!h || !data->hs_data) {
+		xfree(dots);
+		return;
+	}
+
+	if (cfg->gc_width > h->h_definition->hd_size)
+		BUG();
+
+	/* find the largest peak */
+	for (i = 0; i < cfg->gc_width; i++) {
+		uint64_t v = graph_data_at(h, data, i);
+
+		if (v != HISTORY_UNKNOWN && max < v)
+			max = v;
+	}
+
+	step = (double) max / (double) cfg->gc_height;
+	dot_step = step / (double) GRAPH_BRAILLE_ROWS;
+
+	for (i = 0; i < cfg->gc_height; i++)
+		tbl->gt_scale[i] = (double) (i + 1) * step;
+
+	for (i = 0; i < cfg->gc_width; i++) {
+		uint64_t left = graph_data_at(h, data, i);
+		double right;
+
+		if (left == HISTORY_UNKNOWN) {
+			fill_braille_unknown(cfg, dots, i);
+			continue;
+		}
+
+		right = (double) left;
+		if (i < (cfg->gc_width - 1)) {
+			uint64_t next = graph_data_at(h, data, i + 1);
+
+			if (next != HISTORY_UNKNOWN)
+				right = (((double) left) + ((double) next)) / 2.0f;
+		}
+
+		braille_plot_value(cfg, dots, i, 0, (double) left, dot_step);
+		braille_plot_value(cfg, dots, i, 1, right, dot_step);
+	}
+
+	render_braille_table(cfg, tbl->gt_table, dots);
+	xfree(dots);
+
+	n = (cfg->gc_height / 3) * 2;
+	if (n >= cfg->gc_height)
+		n = (cfg->gc_height - 1);
+
+	divisor = unit_divisor(tbl->gt_scale[n], cfg->gc_unit,
+			       &tbl->gt_y_unit, NULL);
+
+	for (i = 0; i < cfg->gc_height; i++)
+		tbl->gt_scale[i] /= divisor;
 }
 
 static void fill_table(struct graph *g, struct graph_table *tbl,
@@ -66,6 +231,11 @@ static void fill_table(struct graph *g, struct graph_table *tbl,
 	double v;
 	int i, n, t;
 	float half_step, step;
+
+	if (cfg->gc_flags & GRAPH_CFG_BRAILLE) {
+		fill_braille_table(g, tbl, h, data);
+		return;
+	}
 
 	if (!tbl->gt_table) {
 		tbl->gt_table = xcalloc(table_size(cfg), sizeof(char));
@@ -101,7 +271,7 @@ static void fill_table(struct graph *g, struct graph_table *tbl,
 		tbl->gt_scale[i] = (double) (i + 1) * step;
 
 	for (n = h->h_index, i = 0; i < cfg->gc_width; i++) {
-		char * col = at_col(tbl->gt_table, i);
+		char * col = at_col(cfg, tbl->gt_table, i);
 
 		if (--n < 0)
 			n = h->h_definition->hd_size - 1;

--- a/src/graph.c
+++ b/src/graph.c
@@ -163,10 +163,10 @@ static void fill_braille_table(struct graph *g, struct graph_table *tbl,
 	}
 
 	dots = xcalloc(cfg->gc_height * cfg->gc_width, sizeof(*dots));
-	render_braille_table(cfg, tbl->gt_table, dots);
 
 	/* leave table blank if there is no data */
 	if (!h || !data->hs_data) {
+		render_braille_table(cfg, tbl->gt_table, dots);
 		xfree(dots);
 		return;
 	}

--- a/src/out_curses.c
+++ b/src/out_curses.c
@@ -235,8 +235,11 @@ static void center_text(const char *fmt, ...)
 static int curses_init(void)
 {
 	setlocale(LC_CTYPE, "");
-	if ((c_graph_cfg.gc_flags & GRAPH_CFG_BRAILLE) && MB_CUR_MAX < 2)
+	if ((c_graph_cfg.gc_flags & GRAPH_CFG_BRAILLE) && MB_CUR_MAX < 2) {
+		fprintf(stderr,
+			"Braille graphs require a UTF-8 locale, falling back to classic graphs\n");
 		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
+	}
 
 	if (!initscr()) {
 		fprintf(stderr, "Unable to initialize curses screen\n");
@@ -1419,8 +1422,7 @@ static void print_module_help(void)
 	"  Author: Thomas Graf <tgraf@suug.ch>\n" \
 	"\n" \
 	"  Options:\n" \
-	"    braille        Use Braille-smoothed graphs (default)\n" \
-	"    nobraille      Use classic single-character graphs\n" \
+	"    braille[=0|1]  Enable(1)/disable(0) Braille-smoothed graphs (default: 1)\n" \
 	"    fgchar=CHAR    Classic graph foreground character (default: '|')\n" \
 	"    bgchar=CHAR    Classic graph background character (default: '.')\n" \
 	"    nchar=CHAR     Classic graph noise character (default: ':')\n" \
@@ -1468,11 +1470,12 @@ static void curses_parse_opt(const char *type, const char *value)
 		c_show_ipv6 = value ? !!strtol(value, NULL, 0) : 1;
 	else if (!strcasecmp(type, "nocolors"))
 		c_use_colors = 0;
-	else if (!strcasecmp(type, "braille"))
-		c_graph_cfg.gc_flags |= GRAPH_CFG_BRAILLE;
-	else if (!strcasecmp(type, "nobraille"))
-		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
-	else if (!strcasecmp(type, "minlist") && value)
+	else if (!strcasecmp(type, "braille")) {
+		if (value ? !!strtol(value, NULL, 0) : 1)
+			c_graph_cfg.gc_flags |= GRAPH_CFG_BRAILLE;
+		else
+			c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
+	} else if (!strcasecmp(type, "minlist") && value)
 		c_list_min = strtol(value, NULL, 0);
 	else if (!strcasecmp(type, "help")) {
 		print_module_help();

--- a/src/out_curses.c
+++ b/src/out_curses.c
@@ -34,6 +34,8 @@
 #include <bmon/output.h>
 #include <bmon/utils.h>
 
+#include <locale.h>
+
 enum {
 	GRAPH_DISPLAY_SIDE_BY_SIDE = 1,
 	GRAPH_DISPLAY_STANDARD = 2,
@@ -57,6 +59,10 @@ enum {
 
 #define LIST_COL_1		31
 #define LIST_COL_2		55
+
+#define BRAILLE_RX_PAIR		(LAYOUT_MAX + 1)
+#define BRAILLE_TX_PAIR		(LAYOUT_MAX + 2)
+#define BRAILLE_DEFAULT_PAIR	(LAYOUT_MAX + 3)
 
 /* Set to element_current() before drawing */
 static struct element *current_element;
@@ -128,6 +134,7 @@ static struct graph_cfg c_graph_cfg = {
 	.gc_background		= '.',
 	.gc_noise		= ':',
 	.gc_unknown		= '?',
+	.gc_flags		= GRAPH_CFG_BRAILLE,
 };
 
 #define NEXT_ROW()			\
@@ -144,6 +151,31 @@ static void apply_layout(int layout)
 		attrset(COLOR_PAIR(layout) | cfg_layout[layout].l_attr);
 	else
 		attrset(cfg_layout[layout].l_attr);
+}
+
+static void apply_braille_graph_layout(int layout)
+{
+	if (!c_use_colors) {
+		attrset(cfg_layout[layout].l_attr);
+		return;
+	}
+
+	if (layout == LAYOUT_RX_GRAPH)
+		attrset(COLOR_PAIR(BRAILLE_RX_PAIR) | cfg_layout[layout].l_attr);
+	else if (layout == LAYOUT_TX_GRAPH)
+		attrset(COLOR_PAIR(BRAILLE_TX_PAIR) | cfg_layout[layout].l_attr);
+	else
+		apply_layout(layout);
+}
+
+static void apply_braille_default_layout(void)
+{
+	if (c_use_colors) {
+		attrset(COLOR_PAIR(BRAILLE_DEFAULT_PAIR) |
+			cfg_layout[LAYOUT_LIST].l_attr);
+		return;
+	}
+	attrset(A_NORMAL);
 }
 
 static char *float2str(double value, int width, int prec, char *buf, size_t len)
@@ -202,6 +234,10 @@ static void center_text(const char *fmt, ...)
 
 static int curses_init(void)
 {
+	setlocale(LC_CTYPE, "");
+	if ((c_graph_cfg.gc_flags & GRAPH_CFG_BRAILLE) && MB_CUR_MAX < 2)
+		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
+
 	if (!initscr()) {
 		fprintf(stderr, "Unable to initialize curses screen\n");
 		return -EOPNOTSUPP;
@@ -222,6 +258,13 @@ static int curses_init(void)
 #endif
 		for (i = 1; i < LAYOUT_MAX+1; i++)
 			init_pair(i, cfg_layout[i].l_fg, cfg_layout[i].l_bg);
+
+		init_pair(BRAILLE_RX_PAIR, cfg_layout[LAYOUT_RX_GRAPH].l_fg,
+			  cfg_layout[LAYOUT_LIST].l_bg);
+		init_pair(BRAILLE_TX_PAIR, cfg_layout[LAYOUT_TX_GRAPH].l_fg,
+			  cfg_layout[LAYOUT_LIST].l_bg);
+		init_pair(BRAILLE_DEFAULT_PAIR, cfg_layout[LAYOUT_LIST].l_fg,
+			  cfg_layout[LAYOUT_LIST].l_bg);
 	}
 		
 	keypad(stdscr, TRUE);
@@ -700,6 +743,56 @@ static void draw_graph_centered(struct graph *g, int row, int ncol,
 	mvprintw(row, ncol + hcenter, "%.*s", g->g_cfg.gc_width, text);
 }
 
+static int is_braille_blank(const char *p)
+{
+	return (unsigned char) p[0] == 0xe2 &&
+	       (unsigned char) p[1] == 0xa0 &&
+	       (unsigned char) p[2] == 0x80;
+}
+
+static void put_graph_row(struct graph *g, const char *line, int layout,
+			  int panel_end)
+{
+	int i, maxcells, fillcells;
+	int x, y;
+
+	if (!(g->g_cfg.gc_flags & GRAPH_CFG_BRAILLE)) {
+		put_line("%s", line);
+		return;
+	}
+
+	getyx(stdscr, y, x);
+	maxcells = cols - x;
+	if (maxcells < 0)
+		maxcells = 0;
+	if (maxcells > g->g_cfg.gc_width)
+		maxcells = g->g_cfg.gc_width;
+
+	if (panel_end > cols)
+		panel_end = cols;
+	fillcells = panel_end - x;
+	if (fillcells < 0)
+		fillcells = 0;
+	if (fillcells < maxcells)
+		fillcells = maxcells;
+
+	apply_braille_default_layout();
+	for (i = 0; i < fillcells; i++)
+		addch(' ');
+
+	for (i = 0; i < maxcells; i++) {
+		const char *cell = line + (i * GRAPH_BRAILLE_CELL_BYTES);
+
+		if (!is_braille_blank(cell)) {
+			move(y, x + i);
+			apply_braille_graph_layout(layout);
+			addnstr(cell, GRAPH_BRAILLE_CELL_BYTES);
+		}
+	}
+
+	move(y, x + fillcells);
+}
+
 static void draw_table(struct graph *g, struct graph_table *tbl,
 		       struct attr *a, struct history *h,
 		       const char *hdr, int ncol, int layout)
@@ -733,7 +826,10 @@ static void draw_table(struct graph *g, struct graph_table *tbl,
         sprintf(buf, "%'8.2f ", tbl->gt_scale[i]);
         addstr(buf);
         apply_layout(layout);
-        put_line("%s", tbl->gt_table + (i * graph_row_size(&g->g_cfg)));
+        put_graph_row(g, tbl->gt_table + (i * graph_row_size(&g->g_cfg)),
+		      layout,
+		      graph_display == GRAPH_DISPLAY_SIDE_BY_SIDE && !ncol ?
+		      cols / 2 : cols);
         apply_layout(LAYOUT_LIST);
 	}
 
@@ -1323,10 +1419,12 @@ static void print_module_help(void)
 	"  Author: Thomas Graf <tgraf@suug.ch>\n" \
 	"\n" \
 	"  Options:\n" \
-	"    fgchar=CHAR    Foreground character (default: '|')\n" \
-	"    bgchar=CHAR    Background character (default: '.')\n" \
-	"    nchar=CHAR     Noise character (default: ':')\n" \
-	"    uchar=CHAR     Unknown character (default: '?')\n" \
+	"    braille        Use Braille-smoothed graphs (default)\n" \
+	"    nobraille      Use classic single-character graphs\n" \
+	"    fgchar=CHAR    Classic graph foreground character (default: '|')\n" \
+	"    bgchar=CHAR    Classic graph background character (default: '.')\n" \
+	"    nchar=CHAR     Classic graph noise character (default: ':')\n" \
+	"    uchar=CHAR     Classic graph unknown character (default: '?')\n" \
 	"    gheight=NUM    Height of graph (default: 6)\n" \
 	"    gwidth=NUM     Width of graph (default: 60)\n" \
 	"    ngraph=NUM     Number of graphs (default: 1)\n" \
@@ -1341,15 +1439,19 @@ static void print_module_help(void)
 
 static void curses_parse_opt(const char *type, const char *value)
 {
-	if (!strcasecmp(type, "fgchar") && value)
+	if (!strcasecmp(type, "fgchar") && value) {
 		c_graph_cfg.gc_foreground = value[0];
-	else if (!strcasecmp(type, "bgchar") && value)
+		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
+	} else if (!strcasecmp(type, "bgchar") && value) {
 		c_graph_cfg.gc_background = value[0];
-	else if (!strcasecmp(type, "nchar") && value)
+		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
+	} else if (!strcasecmp(type, "nchar") && value) {
 		c_graph_cfg.gc_noise = value[0];
-	else if (!strcasecmp(type, "uchar") && value)
+		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
+	} else if (!strcasecmp(type, "uchar") && value) {
 		c_graph_cfg.gc_unknown = value[0];
-	else if (!strcasecmp(type, "gheight") && value)
+		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
+	} else if (!strcasecmp(type, "gheight") && value)
 		c_graph_cfg.gc_height = strtol(value, NULL, 0);
 	else if (!strcasecmp(type, "gwidth") && value)
 		c_graph_cfg.gc_width = strtol(value, NULL, 0);
@@ -1366,6 +1468,10 @@ static void curses_parse_opt(const char *type, const char *value)
 		c_show_ipv6 = value ? !!strtol(value, NULL, 0) : 1;
 	else if (!strcasecmp(type, "nocolors"))
 		c_use_colors = 0;
+	else if (!strcasecmp(type, "braille"))
+		c_graph_cfg.gc_flags |= GRAPH_CFG_BRAILLE;
+	else if (!strcasecmp(type, "nobraille"))
+		c_graph_cfg.gc_flags &= ~GRAPH_CFG_BRAILLE;
 	else if (!strcasecmp(type, "minlist") && value)
 		c_list_min = strtol(value, NULL, 0);
 	else if (!strcasecmp(type, "help")) {


### PR DESCRIPTION
## Summary

This improves the curses graph rendering by using Unicode Braille cells for higher-resolution RX/TX graphs.

The previous graph renderer used one character per graph cell, which made curves and spikes look blocky. Braille cells provide multiple vertical sub-points per terminal cell, making the graph smoother while keeping the same overall graph dimensions.

## Details

- Adds an optional `GRAPH_CFG_BRAILLE` graph mode.
- Keeps the existing classic single-character graph renderer available.
- Enables Braille rendering by default for curses output.
- Adds `braille` and `nobraille` curses output options.
- Initializes `LC_CTYPE` so ncurses can render UTF-8 Braille characters.
- Uses default/list background colors for Braille graph cells to avoid black blocks around the plot area.
- Leaves ASCII output unchanged.

<img width="1055" height="632" alt="Screenshot 2026-06-17 at 13 40 07" src="https://github.com/user-attachments/assets/888b14f5-4e79-4768-89a9-d2a236519177" />


