### PR TITLE
feat: Add IPv4/IPv6 addresses to additional info

### DIFF
--- a/include/bmon/element.h
+++ b/include/bmon/element.h
@@ -123,6 +123,8 @@ extern void			element_parse_policy(const char *);
 extern void			element_update_info(struct element *,
 						    const char *,
 						    const char *);
+extern void			element_delete_info(struct element *,
+						    const char *);
 
 extern void			element_set_txmax(struct element *, uint64_t);
 extern void			element_set_rxmax(struct element *, uint64_t);

--- a/man/bmon.8
+++ b/man/bmon.8
@@ -138,7 +138,10 @@ The following output modules exist:
 \fBcurses\fR
 Interactive curses based text user interface providing real time rate
 estimations and a graphical representation of each attribute. Press '?'
-to display the quick reference guide. This is the default output mode.
+to display the quick reference guide. Additional interface information
+(including IPv4/IPv6 addresses when using the netlink input) can be
+toggled with '\fBi\fR'; use '\fB4\fR' and '\fB6\fR' to show or hide IPv4
+and IPv6 addresses. This is the default output mode.
 
 .TP
 \fBascii\fR
@@ -219,6 +222,12 @@ and eth1:
 .PP
 .RS 4
 \fBbmon \-p eth0,eth1 \-o curses\fP
+.RE
+.PP
+To start curses with the additional info panel and IPv6 addresses hidden:
+.PP
+.RS 4
+\fBbmon \-o curses:info;ipv6=0\fP
 .RE
 .PP
 To run bmon in format mode, monitoring any eth* interfaces, with a specified

--- a/src/element.c
+++ b/src/element.c
@@ -531,6 +531,22 @@ void element_update_info(struct element *e, const char *name, const char *value)
 	list_add_tail(&i->i_list, &e->e_info_list);
 }
 
+void element_delete_info(struct element *e, const char *name)
+{
+	struct info *i;
+
+	if (!(i = element_info_lookup(e, name)))
+		return;
+
+	xfree(i->i_name);
+	xfree(i->i_value);
+	list_del(&i->i_list);
+	xfree(i);
+
+	if (e->e_ninfo > 0)
+		e->e_ninfo--;
+}
+
 void element_set_txmax(struct element *e, uint64_t max)
 {
 	char buf[32];

--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -42,6 +42,7 @@ static struct bmon_module netlink_ops;
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/utils.h>
+#include <netlink/route/addr.h>
 #include <netlink/route/link.h>
 #include <netlink/route/tc.h>
 #include <netlink/route/qdisc.h>
@@ -64,6 +65,10 @@ static struct bmon_module netlink_ops;
 #if LIBNL_CURRENT < 224
 # define RTNL_LINK_RX_NOHANDLER		-1
 #endif
+
+#define MAX_IPS	16
+#define INET_CIDR_MASK_STRLEN	3
+#define INET6_CIDR_MASK_STRLEN	4
 
 static struct attr_map link_attrs[] = {
 {
@@ -509,8 +514,16 @@ struct rdata {
 	int 			level;
 };
 
+struct link_addrs {
+	int		ifindex;
+	char	inet4_addrs[MAX_IPS][INET_ADDRSTRLEN + INET_CIDR_MASK_STRLEN];
+	int		inet4_count;
+	char	inet6_addrs[MAX_IPS][INET6_ADDRSTRLEN + INET6_CIDR_MASK_STRLEN];
+	int		inet6_count;
+};
+
 static struct nl_sock *sock;
-static struct nl_cache *link_cache, *qdisc_cache;
+static struct nl_cache *link_cache, *qdisc_cache, *addr_cache;
 
 static void update_tc_attrs(struct element *e, struct rtnl_tc *tc)
 {
@@ -718,9 +731,71 @@ static void handle_tc(struct element *e, struct rtnl_link *link)
 	nl_cache_free(class_cache);
 }
 
+static void get_addresses_cb(struct nl_object *obj, void *arg)
+{
+	struct rtnl_addr *addr = (struct rtnl_addr *) obj;
+	struct link_addrs *la = arg;
+	struct nl_addr *local;
+
+	if (rtnl_addr_get_ifindex(addr) == la->ifindex) {
+		local = rtnl_addr_get_local(addr);
+		if (local) {
+			if (rtnl_addr_get_family(addr) == AF_INET &&
+				la->inet4_count < MAX_IPS) {
+				nl_addr2str(local, la->inet4_addrs[la->inet4_count++],
+						sizeof(la->inet4_addrs[0]));
+			} else if (rtnl_addr_get_family(addr) == AF_INET6 &&
+					   la->inet6_count < MAX_IPS) {
+				nl_addr2str(local, la->inet6_addrs[la->inet6_count++],
+						sizeof(la->inet6_addrs[0]));
+			}
+		}
+	}
+}
+
+static void update_link_addrs(struct element *e, struct link_addrs *la)
+{
+	char addr_name_buf[16];
+	uint8_t i;
+
+	for (i = 0; i < la->inet4_count; i++) {
+		snprintf(addr_name_buf, sizeof(addr_name_buf),
+			 "IPv4[%u]", i + 1);
+		element_update_info(e, addr_name_buf, la->inet4_addrs[i]);
+	}
+	for (; i < MAX_IPS; i++) {
+		snprintf(addr_name_buf, sizeof(addr_name_buf),
+			 "IPv4[%u]", i + 1);
+		element_delete_info(e, addr_name_buf);
+	}
+
+	for (i = 0; i < la->inet6_count; i++) {
+		snprintf(addr_name_buf, sizeof(addr_name_buf),
+			 "IPv6[%u]", i + 1);
+		element_update_info(e, addr_name_buf, la->inet6_addrs[i]);
+	}
+	for (; i < MAX_IPS; i++) {
+		snprintf(addr_name_buf, sizeof(addr_name_buf),
+			 "IPv6[%u]", i + 1);
+		element_delete_info(e, addr_name_buf);
+	}
+}
+
 static void update_link_infos(struct element *e, struct rtnl_link *link)
 {
 	char buf[64];
+	int ifindex = rtnl_link_get_ifindex(link);
+	struct link_addrs la = { .ifindex = ifindex };
+	struct rtnl_addr *filter;
+
+	if (addr_cache && (filter = rtnl_addr_alloc())) {
+		rtnl_addr_set_ifindex(filter, ifindex);
+		nl_cache_foreach_filter(addr_cache, OBJ_CAST(filter),
+					get_addresses_cb, &la);
+		rtnl_addr_put(filter);
+	}
+
+	update_link_addrs(e, &la);
 
 	snprintf(buf, sizeof(buf), "%u", rtnl_link_get_mtu(link));
 	element_update_info(e, "MTU", buf);
@@ -732,11 +807,11 @@ static void update_link_infos(struct element *e, struct rtnl_link *link)
 				buf, sizeof(buf));
 	element_update_info(e, "Operstate", buf);
 
-	snprintf(buf, sizeof(buf), "%u", rtnl_link_get_ifindex(link));
+	snprintf(buf, sizeof(buf), "%u", ifindex);
 	element_update_info(e, "IfIndex", buf);
 
 	nl_addr2str(rtnl_link_get_addr(link), buf, sizeof(buf));
-	element_update_info(e, "Address", buf);
+	element_update_info(e, "MAC", buf);
 
 	nl_addr2str(rtnl_link_get_broadcast(link), buf, sizeof(buf));
 	element_update_info(e, "Broadcast", buf);
@@ -796,9 +871,6 @@ static void do_link(struct nl_object *obj, void *arg)
 		    element_set_usage_attr(e, "bytes"))
 			BUG();
 
-		/* FIXME: Update link infos every 1s or so */
-		update_link_infos(e, link);
-
 		e->e_flags &= ~ELEMENT_FLAG_CREATED;
 	}
 
@@ -823,6 +895,8 @@ static void do_link(struct nl_object *obj, void *arg)
 	if (!c_notc && qdisc_cache)
 		handle_tc(e, link);
 
+	update_link_infos(e, link);
+
 	element_notify_update(e, NULL);
 	element_lifesign(e, 1);
 }
@@ -833,6 +907,11 @@ static void netlink_read(void)
 
 	if ((err = nl_cache_resync(sock, link_cache, NULL, NULL)) < 0) {
 		fprintf(stderr, "Unable to resync link cache: %s\n", nl_geterror(err));
+		goto disable;
+	}
+
+	if ((err = nl_cache_resync(sock, addr_cache, NULL, NULL)) < 0) {
+		fprintf(stderr, "Unable to resync addr cache: %s\n", nl_geterror(err));
 		goto disable;
 	}
 
@@ -853,6 +932,7 @@ disable:
 static void netlink_shutdown(void)
 {
 	nl_cache_free(link_cache);
+	nl_cache_free(addr_cache);
 	nl_cache_free(qdisc_cache);
 	nl_socket_free(sock);
 }
@@ -887,6 +967,11 @@ static int netlink_do_init(void)
 		goto disable;
 	}
 
+	if ((err = rtnl_addr_alloc_cache(sock, &addr_cache)) < 0) {
+		fprintf(stderr, "Unable to allocate addr cache: %s\n", nl_geterror(err));
+		goto disable;
+	}
+
 	if ((err = rtnl_qdisc_alloc_cache(sock, &qdisc_cache)) < 0) {
 		fprintf(stderr, "Warning: Unable to allocate qdisc cache: %s\n", nl_geterror(err));
 		fprintf(stderr, "Disabling QoS statistics.\n");
@@ -911,22 +996,30 @@ disable:
 static int netlink_probe(void)
 {
 	struct nl_sock *sock;
-	struct nl_cache *lc;
+	struct nl_cache *lc, *ac;
 	int ret = 0;
 
 	if (!(sock = nl_socket_alloc()))
 		return 0;
 
-	if (nl_connect(sock, NETLINK_ROUTE) < 0)
+	if (nl_connect(sock, NETLINK_ROUTE) < 0) {
+		nl_socket_free(sock);
 		return 0;
-
-	if (rtnl_link_alloc_cache(sock, AF_UNSPEC, &lc) == 0) {
-		nl_cache_free(lc);
-		ret = 1;
 	}
 
-	nl_socket_free(sock);
+	if (rtnl_link_alloc_cache(sock, AF_UNSPEC, &lc) < 0)
+		goto out;
 
+	nl_cache_free(lc);
+
+	if (rtnl_addr_alloc_cache(sock, &ac) < 0)
+		goto out;
+	
+	nl_cache_free(ac);
+	ret = 1;
+
+out:
+	nl_socket_free(sock);
 	return ret;
 }
 

--- a/src/out_curses.c
+++ b/src/out_curses.c
@@ -44,12 +44,15 @@ enum {
 	KEY_TOGGLE_GRAPH	= 'g',
 	KEY_TOGGLE_DETAILS	= 'd',
 	KEY_TOGGLE_INFO		= 'i',
+	KEY_TOGGLE_IPV4		= '4',
+	KEY_TOGGLE_IPV6		= '6',
 	KEY_COLLECT_HISTORY	= 'h',
 	KEY_CTRL_N	= 14,
 	KEY_CTRL_P	= 16,
 };
 
-#define DETAILS_COLS		40
+#define DETAILS_COLS		68
+#define INFO_VALUE_LEN		50
 
 #define LIST_COL_1		31
 #define LIST_COL_2		55
@@ -112,6 +115,8 @@ static int c_use_colors = 1;
 static int c_show_details = 0;
 static int c_show_list = 1;
 static int c_show_info = 0;
+static int c_show_ipv4 = 1;
+static int c_show_ipv6 = 1;
 static int c_list_min = 6;
 
 static struct graph_cfg c_graph_cfg = {
@@ -338,7 +343,7 @@ static void print_message(const char *text)
 static void draw_help(void)
 {
 #define HW 46
-#define HH 19
+#define HH 21
 	int i, y = (rows/2) - (HH/2);
 	int x = (cols/2) - (HW/2);
 	char pad[HW+1];
@@ -387,16 +392,18 @@ static void draw_help(void)
 	mvaddnstr(y+ 9, x+3, "d             Toggle detailed statistics", -1);
 	mvaddnstr(y+10, x+3, "l             Toggle element list", -1);
 	mvaddnstr(y+11, x+3, "i             Toggle additional info", -1);
+	mvaddnstr(y+12, x+3, "4             Toggle IPv4 addresses", -1);
+	mvaddnstr(y+13, x+3, "6             Toggle IPv6 addresses", -1);
 
 	attron(A_BOLD | A_UNDERLINE);
-	mvaddnstr(y+13, x+1, "Graph Settings", -1);
+	mvaddnstr(y+15, x+1, "Graph Settings", -1);
 	attroff(A_BOLD | A_UNDERLINE);
 
-	mvaddnstr(y+14, x+3, "g             Toggle graphical statistics", -1);
-	mvaddnstr(y+15, x+3, "H             Start recording history data", -1);
-	mvaddnstr(y+16, x+3, "TAB           Switch time unit of graph", -1);
-	mvaddnstr(y+17, x+3, "<, >          Change number of graphs", -1);
-	mvaddnstr(y+18, x+3, "r             Reset counter of element", -1);
+	mvaddnstr(y+16, x+3, "g             Toggle graphical statistics", -1);
+	mvaddnstr(y+17, x+3, "H             Start recording history data", -1);
+	mvaddnstr(y+18, x+3, "TAB           Switch time unit of graph", -1);
+	mvaddnstr(y+19, x+3, "<, >          Change number of graphs", -1);
+	mvaddnstr(y+20, x+3, "r             Reset counter of element", -1);
 
 	attroff(A_STANDOUT);
 
@@ -801,18 +808,34 @@ static void draw_graph(void)
 	element_foreach_attr(current_element, &draw_attr_graph, &nattr);
 }
 
+static int info_is_visible(struct info *info)
+{
+	if (!strncasecmp(info->i_name, "IPv4[", 5))
+		return c_show_ipv4;
+	if (!strncasecmp(info->i_name, "IPv6[", 5))
+		return c_show_ipv6;
+	return 1;
+}
+
 static int lines_required_for_info(void)
 {
 	int lines = 1;
 
 	if (c_show_info) {
+		struct info *info;
+		int ninfo = 0;
+
 		info_cols = cols / DETAILS_COLS;
 
 		if (!info_cols)
 			info_cols = 1;
 
-		lines += (current_element->e_ninfo / info_cols);
-		if (current_element->e_ninfo % info_cols)
+		list_for_each_entry(info, &current_element->e_info_list, i_list)
+			if (info_is_visible(info))
+				ninfo++;
+
+		lines += (ninfo / info_cols);
+		if (ninfo % info_cols)
 			lines++;
 	}
 
@@ -823,12 +846,17 @@ static void __draw_info(struct element *e, struct info *info, int *ninfo)
 {
 	int ncol;
 
+	if (!info_is_visible(info))
+		return;
+
 	ncol = ((*ninfo) * DETAILS_COLS) - 1;
+
 	move(row, ncol);
 	if (ncol > 0)
 		addch(ACS_VLINE);
 
-	put_line(" %-14.14s %22.22s", info->i_name, info->i_value);
+	put_line(" %-14.14s %-*.*s", info->i_name,
+		 INFO_VALUE_LEN, INFO_VALUE_LEN, info->i_value);
 
 	if (++(*ninfo) >= info_cols) {
 		NEXT_ROW();
@@ -1164,6 +1192,14 @@ static int handle_input(int ch)
 			c_show_info = !c_show_info;
 			return 1;
 
+		case KEY_TOGGLE_IPV4:
+			c_show_ipv4 = !c_show_ipv4;
+			return 1;
+
+		case KEY_TOGGLE_IPV6:
+			c_show_ipv6 = !c_show_ipv6;
+			return 1;
+
 		case KEY_COLLECT_HISTORY:
 			if (current_attr) {
 				attr_start_collecting_history(current_attr);
@@ -1277,6 +1313,8 @@ static void print_module_help(void)
 	"    graph          Show graphical stats by default\n" \
 	"    details        Show detailed stats by default\n" \
 	"    info           Show additional info screen by default\n" \
+	"    ipv4[=0|1]     Show IPv4 addresses in additional info (default: 1)\n" \
+	"    ipv6[=0|1]     Show IPv6 addresses in additional info (default: 1)\n" \
 	"    minlist=INT    Minimum item list length\n");
 }
 
@@ -1301,6 +1339,10 @@ static void curses_parse_opt(const char *type, const char *value)
 		c_show_details = 1;
 	else if (!strcasecmp(type, "info"))
 		c_show_info = 1;
+	else if (!strcasecmp(type, "ipv4"))
+		c_show_ipv4 = value ? !!strtol(value, NULL, 0) : 1;
+	else if (!strcasecmp(type, "ipv6"))
+		c_show_ipv6 = value ? !!strtol(value, NULL, 0) : 1;
 	else if (!strcasecmp(type, "nocolors"))
 		c_use_colors = 0;
 	else if (!strcasecmp(type, "minlist") && value)


### PR DESCRIPTION
in_netlink.c:
* Add global addr_cache to support getting IPv4/IPv6 addresses
* Get all IPv4/IPv6 addresses per interface (maximum 16 each)
* Rename Address to MAC
* Move update_link_infos() outside of ELEMENT_FLAG_CREATED check to allow updating during input_read()

out_curses.c:
* Show both IPv4 and IPv6 addresses by default
* Allow toggling the display of both IPv4 and IPv6 addresses
* Increase the detail column width to support IPv6 addresses + masks