### PR TITLE
ci: enable -Werror for compiler warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - ci
+      - ci-werror
     paths-ignore:
       - 'README.md'
       - 'NEWS'
@@ -17,6 +18,7 @@ on:
     branches:
       - master
       - ci
+      - ci-werror
     paths-ignore:
       - 'README.md'
       - 'NEWS'
@@ -109,7 +111,7 @@ jobs:
       - name: Configure
         run: |
           ./autogen.sh
-          ./configure
+          ./configure --enable-werror
 
       - name: Make
         id: build
@@ -123,7 +125,7 @@ jobs:
 
       - name: Distcheck
         if: contains(matrix.cfg.os, 'ubuntu:24.04')
-        run: make distcheck
+        run: make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-werror
 
   macOS:
     runs-on: ${{ matrix.cfg.os }}
@@ -150,7 +152,7 @@ jobs:
           export PATH="$(brew --prefix)/opt/gettext/bin:$PATH"
           export PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
           ./autogen.sh
-          ./configure \
+          ./configure --enable-werror \
             CPPFLAGS="-I$(brew --prefix)/include" \
             LDFLAGS="-L$(brew --prefix)/lib"
 
@@ -197,7 +199,7 @@ jobs:
         shell: alpine.sh {0}
         run: |
           ./autogen.sh
-          ./configure
+          ./configure --enable-werror
 
       - name: Make
         id: build
@@ -228,7 +230,7 @@ jobs:
             cd "$GITHUB_WORKSPACE"
             git config --global --add safe.directory "$GITHUB_WORKSPACE"
             ./autogen.sh
-            ./configure
+            ./configure --enable-werror
             gmake -j"$(sysctl -n hw.ncpu)"
             ./src/bmon -o 'ascii:quitafter=1'
 
@@ -252,7 +254,7 @@ jobs:
       - name: Configure
         run: |
           ./autogen.sh
-          ./configure CC=clang
+          ./configure --enable-werror CC=clang
 
       - name: Make
         id: build

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,17 @@ AC_ARG_ENABLE(debug,
 
 #####################################################################
 ##
+## -Werror
+##
+#####################################################################
+AC_ARG_ENABLE([werror],
+	[AS_HELP_STRING([--enable-werror],
+		[treat compiler warnings as errors (default: disabled)])],
+	[], [enable_werror=no])
+AS_IF([test "x$enable_werror" = "xyes"], [WERROR="-Werror"], [WERROR=""])
+
+#####################################################################
+##
 ## target os eval
 ##
 #####################################################################
@@ -195,6 +206,7 @@ AC_SUBST(DEBUG)
 AC_SUBST(STATIC)
 AC_SUBST(SYS)
 AC_SUBST(ARCH)
+AC_SUBST(WERROR)
 
 AC_SUBST(CURSES)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,7 @@ bmon_CFLAGS = \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \
 	-D_GNU_SOURCE \
 	-Wall \
+	$(WERROR) \
 	$(CURSES_CFLAGS) \
 	$(CONFUSE_CFLAGS) \
 	$(LIBNL_CFLAGS) \

--- a/src/graph.c
+++ b/src/graph.c
@@ -62,7 +62,7 @@ static void fill_table(struct graph *g, struct graph_table *tbl,
 		       struct history *h, struct history_store *data)
 {
 	struct graph_cfg *cfg = &g->g_cfg;
-	uint64_t max = 0;
+	uint64_t max = 0, hv;
 	double v;
 	int i, n, t;
 	float half_step, step;
@@ -89,9 +89,9 @@ static void fill_table(struct graph *g, struct graph_table *tbl,
 	for (n = h->h_index, i = 0; i < cfg->gc_width; i++) {
 		if (--n < 0)
 			n = h->h_definition->hd_size - 1;
-		v = history_data(h, data, n);
-		if (v != HISTORY_UNKNOWN && max < v)
-			max = v;
+		hv = history_data(h, data, n);
+		if (hv != HISTORY_UNKNOWN && max < hv)
+			max = hv;
 	}
 
 	step = (double) max / (double) cfg->gc_height;
@@ -105,16 +105,16 @@ static void fill_table(struct graph *g, struct graph_table *tbl,
 
 		if (--n < 0)
 			n = h->h_definition->hd_size - 1;
-		v = history_data(h, data, n);
+		hv = history_data(h, data, n);
 
-		if (v == HISTORY_UNKNOWN) {
+		if (hv == HISTORY_UNKNOWN) {
 			for (t = 0; t < cfg->gc_height; t++)
 				*(at_row(cfg, col, t)) = cfg->gc_unknown;
-		} else if (v > 0) {
+		} else if (hv > 0) {
 			*(at_row(cfg, col, 0)) = cfg->gc_noise;
 
 			for (t = 0; t < cfg->gc_height; t++)
-				if (v >= (tbl->gt_scale[t] - half_step))
+				if ((double) hv >= (tbl->gt_scale[t] - half_step))
 					*(at_row(cfg, col, t)) = cfg->gc_foreground;
 		}
 	}

--- a/src/out_format.c
+++ b/src/out_format.c
@@ -101,7 +101,7 @@ static char *get_token(struct element_group *g, struct element *e,
 		}
 	} else if (!strncasecmp(token, "attr:", 5)) {
 		const char *type = token + 5;
-		char *name = strchr(type, ':');
+		const char *name = strchr(type, ':');
 		struct attr_def *def;
 		struct attr *a;
 


### PR DESCRIPTION
Add a configure --enable-werror option and use it in CI so new warnings fail the build without forcing -Werror on normal installs.