### PR TITLE
feat: Add ability to toggle TC elements

### DIFF
--- a/include/bmon/input.h
+++ b/include/bmon/input.h
@@ -34,6 +34,7 @@ extern int input_set(const char *, bool update);
 extern void input_register(struct bmon_module *);
 extern void input_read(void);
 extern int input_is_enabled(const char *name);
+extern int input_get_opt(const char *name, const char *opt);
 
 struct reader_timing
 {

--- a/include/bmon/input.h
+++ b/include/bmon/input.h
@@ -30,9 +30,10 @@
 #include <bmon/conf.h>
 #include <bmon/module.h>
 
-extern int input_set(const char *);
+extern int input_set(const char *, bool update);
 extern void input_register(struct bmon_module *);
 extern void input_read(void);
+extern int input_is_enabled(const char *name);
 
 struct reader_timing
 {

--- a/include/bmon/module.h
+++ b/include/bmon/module.h
@@ -70,7 +70,7 @@ extern void		module_foreach_run_enabled(struct bmon_subsys *);
 extern void		module_foreach_run_enabled_post(struct bmon_subsys *);
 
 extern int		module_register(struct bmon_subsys *, struct bmon_module *);
-extern int		module_set(struct bmon_subsys *, const char *);
+extern int		module_set(struct bmon_subsys *, const char *, bool update);
 
 extern void		module_init(void);
 extern void		module_shutdown(void);

--- a/include/bmon/module.h
+++ b/include/bmon/module.h
@@ -44,7 +44,7 @@ struct bmon_module
 	void		      (*m_shutdown)(void);
 
 	void		      (*m_parse_opt)(const char *, const char *);
-	void		      (*m_get_opt)(const char *);
+	int		      (*m_get_opt)(const char *);
 
 	void		      (*m_pre)(void);
 	void		      (*m_do)(void);

--- a/include/bmon/module.h
+++ b/include/bmon/module.h
@@ -44,6 +44,7 @@ struct bmon_module
 	void		      (*m_shutdown)(void);
 
 	void		      (*m_parse_opt)(const char *, const char *);
+	void		      (*m_get_opt)(const char *);
 
 	void		      (*m_pre)(void);
 	void		      (*m_do)(void);
@@ -71,6 +72,7 @@ extern void		module_foreach_run_enabled_post(struct bmon_subsys *);
 
 extern int		module_register(struct bmon_subsys *, struct bmon_module *);
 extern int		module_set(struct bmon_subsys *, const char *, bool update);
+extern int		module_get_opt(struct bmon_subsys *, const char *, const char *);
 
 extern void		module_init(void);
 extern void		module_shutdown(void);

--- a/src/bmon.c
+++ b/src/bmon.c
@@ -185,7 +185,7 @@ static int parse_args_post(int argc, char *argv[])
 		switch (c)
 		{
 			case 'i':
-				if (input_set(optarg))
+				if (input_set(optarg, false))
 					return 1;
 				break;
 

--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -1062,8 +1062,9 @@ static void print_help(void)
 	"  Author: Thomas Graf <tgraf@suug.ch>\n" \
 	"\n" \
 	"  Options:\n" \
-	"    notc[=0|1]     Toggle collection of traffic control\n" \
-	"                   statistics [default: 1]\n");
+	"    notc[=0|1]     Enable(0)/disable(1) collection of traffic\n" \
+	"                   control statistics (bare notc implies 1,\n" \
+	"                   default if not specified is enabled)\n");
 }
 
 static void netlink_parse_opt(const char *type, const char *value)
@@ -1076,12 +1077,21 @@ static void netlink_parse_opt(const char *type, const char *value)
 	}
 }
 
+static int netlink_get_opt(const char *opt)
+{
+	if (!strcasecmp(opt, "notc"))
+		return c_notc;
+	else
+		return -EINVAL;
+}
+
 static struct bmon_module netlink_ops = {
 	.m_name		= "netlink",
 	.m_flags	= BMON_MODULE_DEFAULT,
 	.m_do		= netlink_read,
 	.m_shutdown	= netlink_shutdown,
 	.m_parse_opt	= netlink_parse_opt,
+	.m_get_opt		= netlink_get_opt,
 	.m_probe	= netlink_probe,
 	.m_init		= netlink_do_init,
 };

--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -532,6 +532,17 @@ struct link_addrs {
 static struct nl_sock *sock;
 static struct nl_cache *link_cache, *qdisc_cache, *addr_cache;
 
+static void element_free_tc(struct element *e)
+{
+	struct element *c, *cnext;
+	list_for_each_entry_safe(c, cnext, &e->e_childs, e_list) {
+		if (!strncasecmp(c->e_name, "class ", 6) ||
+			!strncasecmp(c->e_name, "qdisc ", 6) ||
+			!strncasecmp(c->e_name, "cls ", 4))
+			element_free(c);
+	}
+}
+
 static void update_tc_attrs(struct element *e, struct rtnl_tc *tc)
 {
 	int i;
@@ -706,11 +717,18 @@ static void handle_tc(struct element *e, struct rtnl_link *link)
 {
 	struct rtnl_qdisc *qdisc;
 	struct nl_cache *class_cache;
-	int ifindex = rtnl_link_get_ifindex(link);
+	int ifindex;
 	struct rdata rdata = {
 		.level = 1,
 		.parent = e,
 	};
+
+	if (c_notc) {
+		element_free_tc(e);
+		return;
+	}
+
+	ifindex = rtnl_link_get_ifindex(link);
 
 	if (rtnl_class_alloc_cache(sock, ifindex, &class_cache) < 0)
 		return;
@@ -903,7 +921,7 @@ static void do_link(struct nl_object *obj, void *arg)
 		attr_update(e, m->attrid, c_rx, c_tx, flags);
 	}
 
-	if (!c_notc && qdisc_cache)
+	if (qdisc_cache)
 		handle_tc(e, link);
 
 	update_link_infos(e, link);
@@ -1044,13 +1062,14 @@ static void print_help(void)
 	"  Author: Thomas Graf <tgraf@suug.ch>\n" \
 	"\n" \
 	"  Options:\n" \
-	"    notc           Do not collect traffic control statistics\n");
+	"    notc[=0|1]     Toggle collection of traffic control\n" \
+	"                   statistics [default: 1]\n");
 }
 
 static void netlink_parse_opt(const char *type, const char *value)
 {
 	if (!strcasecmp(type, "notc"))
-		c_notc = 1;
+		c_notc = value ? !!strtol(value, NULL, 0) : 1;
 	else if (!strcasecmp(type, "help")) {
 		print_help();
 		exit(0);

--- a/src/input.c
+++ b/src/input.c
@@ -90,6 +90,11 @@ int input_is_enabled(const char *name)
 	return 0;
 }
 
+int input_get_opt(const char *name, const char* opt)
+{
+	return module_get_opt(&input_subsys, name, opt);
+}
+
 static struct bmon_subsys input_subsys = {
 	.s_name			= "input",
 	.s_activate_default	= &activate_default,

--- a/src/input.c
+++ b/src/input.c
@@ -45,22 +45,22 @@ static void activate_default(void)
 		struct bmon_module *m;
 
 #ifdef SYS_LINUX
-		if (!input_set("netlink"))
+		if (!input_set("netlink", false))
 			return;
 
-		if (!input_set("proc"))
+		if (!input_set("proc", false))
 			return;
 #endif
 
 #ifdef SYS_BSD
-		if (!input_set("sysctl"))
+		if (!input_set("sysctl", false))
 			return;
 #endif
 
 		/* Fall back to anything that could act as default */
 		list_for_each_entry(m, &input_subsys.s_mod_list, m_list) {
 			if (m->m_flags & BMON_MODULE_DEFAULT)
-				if (!input_set(m->m_name))
+				if (!input_set(m->m_name, false))
 					return;
 		}
 
@@ -73,9 +73,21 @@ void input_read(void)
 	module_foreach_run_enabled(&input_subsys);
 }
 
-int input_set(const char *name)
+int input_set(const char *name, bool update)
 {
-	return module_set(&input_subsys, name);
+	return module_set(&input_subsys, name, update);
+}
+
+int input_is_enabled(const char *name)
+{
+	struct bmon_module *m;
+
+	list_for_each_entry(m, &input_subsys.s_mod_list, m_list) {
+		if (!strcmp(name, m->m_name) &&
+			(m->m_flags & BMON_MODULE_ENABLED))
+			return 1;
+	}
+	return 0;
 }
 
 static struct bmon_subsys input_subsys = {

--- a/src/module.c
+++ b/src/module.c
@@ -88,7 +88,7 @@ static void module_list(struct bmon_subsys *ss, struct list_head *list)
 	}
 }
 
-static int module_configure(struct bmon_module *m, module_conf_t *cfg)
+static int module_configure(struct bmon_module *m, module_conf_t *cfg, bool update)
 {
 	DBG("Configuring module %s", m->m_name);
 
@@ -99,11 +99,14 @@ static int module_configure(struct bmon_module *m, module_conf_t *cfg)
 			m->m_parse_opt(tv->tv_type, tv->tv_value);
 	}
 
-	if (m->m_probe && !m->m_probe())
+	/* No need to probe on update, already checked that the module is enabled */
+	if (!update && m->m_probe && !m->m_probe())
 		return -EINVAL;
 
-	m->m_flags |= BMON_MODULE_ENABLED;
-	m->m_subsys->s_nmod++;
+	if (!(m->m_flags & BMON_MODULE_ENABLED)) {
+		m->m_flags |= BMON_MODULE_ENABLED;
+		m->m_subsys->s_nmod++;
+	}
 
 	return 0;
 }
@@ -122,12 +125,12 @@ static void __auto_load(struct bmon_module *m)
 {
 	if ((m->m_flags & BMON_MODULE_AUTO) &&
 	    !(m->m_flags & BMON_MODULE_ENABLED)) {
-		if (module_configure(m, NULL) == 0)
+		if (module_configure(m, NULL, false) == 0)
 			DBG("Auto-enabled module %s", m->m_name);
 	}
 }
 
-int module_set(struct bmon_subsys *ss, const char *name)
+int module_set(struct bmon_subsys *ss, const char *name, bool update)
 {
 	struct bmon_module *mod;
 	LIST_HEAD(tmp_list);
@@ -145,8 +148,12 @@ int module_set(struct bmon_subsys *ss, const char *name)
 		if (!(mod = module_lookup(ss, m->m_name)))
 			quit("Unknown %s module: %s\n", ss->s_name, m->m_name);
 
-		if (module_configure(mod, m) == 0)
-			DBG("Enabled module %s", mod->m_name);
+		/* Only update if module is enabled */
+		if (!update || 
+			(update && (mod->m_flags & BMON_MODULE_ENABLED))) {
+			if (module_configure(mod, m, update) == 0)
+				DBG("%s module %s", (update ? "Updated" : "Enabled"), mod->m_name);
+		}
 		
 		list_for_each_entry_safe(tv, tvnext, &m->m_attrs, tv_list) {
 			xfree(tv->tv_value);
@@ -159,7 +166,8 @@ int module_set(struct bmon_subsys *ss, const char *name)
 		xfree(m);
 	}
 
-	module_foreach(ss, __auto_load);
+	if (!update)
+		module_foreach(ss, __auto_load);
 
 	if (!ss->s_nmod)
 		quit("No working %s module found\n", ss->s_name);

--- a/src/module.c
+++ b/src/module.c
@@ -177,6 +177,18 @@ int module_set(struct bmon_subsys *ss, const char *name, bool update)
 	return 0;
 }
 
+int module_get_opt(struct bmon_subsys *ss, const char *name, const char* opt)
+{
+	struct bmon_module *mod;
+	if (!(mod = module_lookup(ss, name)))
+		quit("Unknown %s module: %s\n", ss->s_name, name);
+
+	if ((mod->m_flags & BMON_MODULE_ENABLED) && mod->m_get_opt)
+		return mod->m_get_opt(opt);
+
+	return -EINVAL;
+}
+
 static void __module_init(struct bmon_module *m)
 {
 	if (m->m_init) {

--- a/src/out_curses.c
+++ b/src/out_curses.c
@@ -231,6 +231,8 @@ static int curses_init(void)
 	nodelay(stdscr, TRUE);	  /* getch etc. must be non-blocking */
 	clear();
 	curs_set(0);
+	if (input_is_enabled("netlink"))
+		c_show_tc = !input_get_opt("netlink", "notc");
 
 	return 0;
 }

--- a/src/out_curses.c
+++ b/src/out_curses.c
@@ -46,6 +46,7 @@ enum {
 	KEY_TOGGLE_INFO		= 'i',
 	KEY_TOGGLE_IPV4		= '4',
 	KEY_TOGGLE_IPV6		= '6',
+	KEY_TOGGLE_TC		= 't',
 	KEY_COLLECT_HISTORY	= 'h',
 	KEY_CTRL_N	= 14,
 	KEY_CTRL_P	= 16,
@@ -117,6 +118,7 @@ static int c_show_list = 1;
 static int c_show_info = 0;
 static int c_show_ipv4 = 1;
 static int c_show_ipv6 = 1;
+static int c_show_tc = 1;
 static int c_list_min = 6;
 
 static struct graph_cfg c_graph_cfg = {
@@ -343,7 +345,7 @@ static void print_message(const char *text)
 static void draw_help(void)
 {
 #define HW 46
-#define HH 21
+#define HH 22
 	int i, y = (rows/2) - (HH/2);
 	int x = (cols/2) - (HW/2);
 	char pad[HW+1];
@@ -391,19 +393,20 @@ static void draw_help(void)
 
 	mvaddnstr(y+ 9, x+3, "d             Toggle detailed statistics", -1);
 	mvaddnstr(y+10, x+3, "l             Toggle element list", -1);
-	mvaddnstr(y+11, x+3, "i             Toggle additional info", -1);
-	mvaddnstr(y+12, x+3, "4             Toggle IPv4 addresses", -1);
-	mvaddnstr(y+13, x+3, "6             Toggle IPv6 addresses", -1);
+	mvaddnstr(y+11, x+3, "t             Toggle TC elements", -1);
+	mvaddnstr(y+12, x+3, "i             Toggle additional info", -1);
+	mvaddnstr(y+13, x+3, "4             Toggle IPv4 addresses", -1);
+	mvaddnstr(y+14, x+3, "6             Toggle IPv6 addresses", -1);
 
 	attron(A_BOLD | A_UNDERLINE);
-	mvaddnstr(y+15, x+1, "Graph Settings", -1);
+	mvaddnstr(y+16, x+1, "Graph Settings", -1);
 	attroff(A_BOLD | A_UNDERLINE);
 
-	mvaddnstr(y+16, x+3, "g             Toggle graphical statistics", -1);
-	mvaddnstr(y+17, x+3, "H             Start recording history data", -1);
-	mvaddnstr(y+18, x+3, "TAB           Switch time unit of graph", -1);
-	mvaddnstr(y+19, x+3, "<, >          Change number of graphs", -1);
-	mvaddnstr(y+20, x+3, "r             Reset counter of element", -1);
+	mvaddnstr(y+17, x+3, "g             Toggle graphical statistics", -1);
+	mvaddnstr(y+18, x+3, "H             Start recording history data", -1);
+	mvaddnstr(y+19, x+3, "TAB           Switch time unit of graph", -1);
+	mvaddnstr(y+20, x+3, "<, >          Change number of graphs", -1);
+	mvaddnstr(y+21, x+3, "r             Reset counter of element", -1);
 
 	attroff(A_STANDOUT);
 
@@ -1135,6 +1138,17 @@ static void reset_counters(void)
 	element_foreach_attr(current_element, __reset_attr_counter, NULL);
 }
 
+static void toggle_tc_elements(int enable)
+{
+	if (input_is_enabled("netlink")) {
+		if (enable) {
+			input_set("netlink:notc=0", true);
+		} else {
+			input_set("netlink:notc=1", true);
+		}
+	}
+}
+
 static int handle_input(int ch)
 {
 	switch (ch) 
@@ -1198,6 +1212,11 @@ static int handle_input(int ch)
 
 		case KEY_TOGGLE_IPV6:
 			c_show_ipv6 = !c_show_ipv6;
+			return 1;
+
+		case KEY_TOGGLE_TC:
+			c_show_tc = !c_show_tc;
+			toggle_tc_elements(c_show_tc);
 			return 1;
 
 		case KEY_COLLECT_HISTORY:

--- a/src/output.c
+++ b/src/output.c
@@ -80,7 +80,7 @@ void output_post(void)
 
 int output_set(const char *name)
 {
-	return module_set(&output_subsys, name);
+	return module_set(&output_subsys, name, false);
 }
 
 static struct bmon_subsys output_subsys = {


### PR DESCRIPTION
module/input/output:
* Add "update" argument to module_set()/module_configure() to allow configuring a single
  module without re-configuring all auto-loaded modules
* Add module_get_opt() which returns the value of the option if the
  module specified is enabled, EINVAL otherwise
* Implement module_get_opt() for input modules

in_netlink.c:
* Update "notc" option to accept 0 or 1 as value
* Support toggling "notc" at runtime

out_curses.c:
* Provide toggle/passthrough for "notc" option to netlink module
* Use netlink:notc value to initialize c_show_tc in curses output module

Closes https://github.com/tgraf/bmon/issues/99