### PR TITLE
Fix spelling and grammar in docs and comments

### DIFF
--- a/include/bmon/attr.h
+++ b/include/bmon/attr.h
@@ -42,7 +42,7 @@ struct rate
 	/* Value of r_current at last read */
 	uint64_t		r_prev;
 
-	/* Reset value to substract to emulate statistics reset */
+	/* Reset value to subtract to emulate statistics reset */
 	uint64_t		r_reset;
 
 	/* Rate per second calculated every `rate_interval' */

--- a/man/bmon.8
+++ b/man/bmon.8
@@ -60,7 +60,7 @@ INTERFACE SELECTION for more details.
 .PP
 \fB \-a\fR, \fB\-\-show\-all\fR
 .RS 4
-Display all interfaces, even interface that are administratively down.
+Display all interfaces, even interfaces that are administratively down.
 .RE
 .PP
 \fB \-r\fR, \fB\-\-read\-interval=\fRFLOAT
@@ -89,10 +89,10 @@ without receiving any statistical updates. The default is 30 seconds.
 .SH "INPUT MODULES"
 .PP
 Input modules provide statistical data about elements. Each element consists
-of attributes which represents a counter, a rate, or a percentage. Elements
+of attributes which represent a counter, a rate, or a percentage. Elements
 may carry additional child elements to represent a hierarchy. Each element is
 assigned to a group defined by the input module. Input modules are polled in
-the frequence of the configured read interval.
+the frequency of the configured read interval.
 .PP
 The following input modules are available:
 .TP
@@ -103,7 +103,7 @@ from the kernel. This is the default input module.
 .TP
 \fBproc\fR
 Reads interface statistics from the /proc/net/dev file. This is considered a
-legacy interface and provided for backwards compatibily reasons. This is a
+legacy interface and provided for backwards compatibility reasons. This is a
 fallback module if the Netlink interface is not available.
 
 .TP
@@ -152,7 +152,7 @@ available.
 
 .TP
 \fBformat\fR
-Fully scriptable output mode inteded for consumption by other programs.
+Fully scriptable output mode intended for consumption by other programs.
 See the module help text for additional information.
 
 .TP

--- a/src/unit.c
+++ b/src/unit.c
@@ -68,10 +68,10 @@ struct unit *unit_lookup(const char *name)
  * Searches for the best divisor to be used depending on the unit
  * exponent configured by the user. If a dynamic exponent is
  * configured, the divisor is selected based on the value of hint
- * so that hint is dividied into a small float >= 1.0. The name
+ * so that hint is divided into a small float >= 1.0. The name
  * of the divisor used is stored in *name.
  *
- * If prec points to a vaild integer, a number of precision digits
+ * If prec points to a valid integer, a number of precision digits
  * is suggested to avoid n.00 to make pretty printing easier.
  */
 double unit_divisor(uint64_t hint, struct unit *unit, char **name,


### PR DESCRIPTION
Correct typos in the man page (including inteded/intended) and a few comment misspellings in unit.c and attr.h.